### PR TITLE
Fetch CircleCI results in parallel

### DIFF
--- a/src/Jenkins.js
+++ b/src/Jenkins.js
@@ -25,6 +25,34 @@ export class Jenkins {
     }
   }
 
+  async batch_get(urls, options) {
+    if (options === undefined) options = {};
+    let r;
+    let requests = urls.map(url => {
+      return axios.get(url, { params: options }).then(
+        (response) => ({response}),
+        (err) => ({err}));
+    });
+
+    await axios.all(requests)
+    .then(response => {
+      r = response;
+    })
+    .catch(error => {
+      // console.log("error.response: ", error.response)
+    });
+    if (typeof r !== 'undefined') {
+      return r.map(result => {
+        if (result.response) {
+          return result.response.data;
+        }
+        return null;
+      });
+    } else {
+      return null;
+    }
+  }
+
   async computer(options) { return this.get(this.url("computer"), options); }
   async queue(options) { return this.get(this.url("queue"), options); }
   async job(v, options) { return this.get(this.url("job/" + v), options); }


### PR DESCRIPTION
Adds `batch_get` to `jenkins` to request all logs simultaneously. Reduces page load time by about half

Request waterfall before
<img width="1499" alt="screen shot 2018-11-28 at 11 52 53 pm" src="https://user-images.githubusercontent.com/9407960/49207085-d4f87080-f368-11e8-90e2-c5a38464a5f2.png">

After
<img width="1505" alt="screen shot 2018-11-28 at 11 47 24 pm" src="https://user-images.githubusercontent.com/9407960/49207136-f35e6c00-f368-11e8-89cf-b4281c573a09.png">

