### PR TITLE
Fix non-Jenkins URLs in CI HUD

### DIFF
--- a/src/BuildHistoryDisplay.js
+++ b/src/BuildHistoryDisplay.js
@@ -514,7 +514,6 @@ export default class BuildHistoryDisplay extends Component {
             } else {
               cellHref = jenkins.link(cellHref + "/console")
             }
-            const cellHref = /^https?:\/\//.test(sb.url) ?
             cell = <a href={cellHref}
                       className="icon"
                       target="_blank"

--- a/src/BuildHistoryDisplay.js
+++ b/src/BuildHistoryDisplay.js
@@ -506,7 +506,16 @@ export default class BuildHistoryDisplay extends Component {
           } else if (this.props.mode === "cost") {
             cell = <Fragment>{node === 'unknown' ? '?' : this_cost}&nbsp;&nbsp;</Fragment>;
           } else {
-            cell = <a href={/^https?:\/\//.test(sb.url) ? sb.url + "/console" : jenkins.link(sb.url + "/console")}
+            var cellHref = sb.url;
+            if (/^https?:\/\//.test(cellHref)) {
+              if (cellHref.includes('jenkins')) {
+                cellHref = cellHref + "/console";
+              }
+            } else {
+              cellHref = jenkins.link(cellHref + "/console")
+            }
+            const cellHref = /^https?:\/\//.test(sb.url) ?
+            cell = <a href={cellHref}
                       className="icon"
                       target="_blank"
                       alt={getJobName(sb)}>


### PR DESCRIPTION
These "/console" links coincidentally work on CircleCI, but they break on GitHub Actions.

Example:
https://github.com/pytorch/pytorch/runs/1028673867/console
vs
https://github.com/pytorch/pytorch/runs/1028673867

Incidentally, the HUD is also including non-CI actions in its results, which may or may not be intentional? The job I linked above is a workflow-style action that is triggered any time an Issue is created, not by any commit.

Test Plan: ??? sorry, don't really know how to get this web app running locally.