### PR TITLE
sanitize binary link for all branches in new style

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,9 +14,14 @@ const App = () => (
       </header>
       <ul className="menu">
         <li>New-style (warning, does NOT show Jenkins builds):</li>
-        <li><Link to="/build2/pytorch-master">pytorch-master</Link></li>
-        <li><Link to="/build2/pytorch-nightly?mode=nightly">pytorch-nightly</Link></li>
-        <li><Link to="/build2/pytorch-release/1.7">pytorch-release/1.7</Link></li>
+	{["pytorch",
+	].map((e) => <Fragment key={e}>
+		{["master", "nightly", "release/1.7"
+		].map((trigger) => <li key={e + "-" + trigger}>
+			<Link to={"/build2/" + e + "-" + trigger}>{e}-{trigger}</Link>&nbsp;
+			(<Link to={"/build2/" + e + "-" + trigger + "?mode=nightly"}>binary</Link>)
+		</li>)}
+	</Fragment>)}
       </ul>
       <ul className="deprecated-menu">
         <li>Old-style:</li>

--- a/src/App.js
+++ b/src/App.js
@@ -18,8 +18,8 @@ const App = () => (
 	].map((e) => <Fragment key={e}>
 		{["master", "nightly", "release/1.7"
 		].map((trigger) => <li key={e}-{trigger}>
-			<Link to={"/build2/" + e + "-" + trigger}>{e}-{trigger}</Link>&nbsp;
-			(<Link to={"/build2/" + e + "-" + trigger + "?mode=nightly"}>binary</Link>)
+			<Link to="/build2/{e}-{trigger}">{e}-{trigger}</Link>&nbsp;
+			(<Link to="/build2/{e}-{trigger}?mode=nightly"}>binary</Link>)
 		</li>)}
 	</Fragment>)}
       </ul>

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ const App = () => (
 	{["pytorch",
 	].map((e) => <Fragment key={e}>
 		{["master", "nightly", "release/1.7"
-		].map((trigger) => <li key={e + "-" + trigger}>
+		].map((trigger) => <li key={e}-{trigger}>
 			<Link to={"/build2/" + e + "-" + trigger}>{e}-{trigger}</Link>&nbsp;
 			(<Link to={"/build2/" + e + "-" + trigger + "?mode=nightly"}>binary</Link>)
 		</li>)}

--- a/src/App.js
+++ b/src/App.js
@@ -17,9 +17,9 @@ const App = () => (
 	{["pytorch",
 	].map((e) => <Fragment key={e}>
 		{["master", "nightly", "release/1.7"
-		].map((trigger) => <li key={e}-{trigger}>
-			<Link to="/build2/{e}-{trigger}">{e}-{trigger}</Link>&nbsp;
-			(<Link to="/build2/{e}-{trigger}?mode=nightly"}>binary</Link>)
+		].map((trigger) => <li key={`${e}-${trigger}`}>
+			<Link to={`/build2/${e}-${trigger}`}>{e}-{trigger}</Link>&nbsp;
+			(<Link to={`/build2/${e}-${trigger}?mode=nightly`}>binary</Link>)
 		</li>)}
 	</Fragment>)}
       </ul>


### PR DESCRIPTION
added links to separate CI-builds and CI-Binary-builds for both nightly and release/1.7 branch.

Preview:
![screenshot](https://user-images.githubusercontent.com/3581352/95922657-9efbe400-0d68-11eb-92c8-d21eefbb047c.png)
