### PR TITLE
Deploy to GitHub Pages automatically via GitHub Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,20 @@
+name: GitHub Pages
+on:
+  push:
+    branches:
+      - master
+jobs:
+  pages:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build


### PR DESCRIPTION
According to [the `peaceiris/actions-gh-pages` README](https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-first-deployment-with-github_token), some additional setup may be required via this repo's Settings tab. I didn't need to do anything when I [tested it on my fork](https://github.com/samestep/pytorch-ci-hud/runs/1294049783), though.