### PR TITLE
Ignore GHA workflow_run jobs

### DIFF
--- a/src/GitHubStatusDisplay.js
+++ b/src/GitHubStatusDisplay.js
@@ -24,6 +24,15 @@ function nightly_run_on_pr(job_name) {
   return binary_and_smoke_tests_on_pr.some((n) => job_name.includes(n));
 }
 
+const gha_workflow_run_job_names = new Set([
+  'annotate',
+  'cancel',
+])
+
+function gha_workflow_run_job(job_name) {
+  return gha_workflow_run_job_names.has(job_name.split(' ')[0]);
+}
+
 function is_success(result) {
   return result === 'SUCCESS' || result === 'success';
 }
@@ -128,8 +137,10 @@ export default class BuildHistoryDisplay extends Component {
       build.sb_map.forEach((sb, job_name) => {
         const nightly_candidates = job_name.includes("binary_") || job_name.includes("smoke_") || job_name.includes("nightly_") || job_name.includes("nigthly_");
         const is_nightly = nightly_candidates && !nightly_run_on_pr(job_name);
-        if ((props_mode !== "nightly" && !is_nightly) ||
-            (props_mode === "nightly" && is_nightly)) {
+        const correct_nightliness =
+          (props_mode !== "nightly" && !is_nightly) ||
+          (props_mode === "nightly" && is_nightly);
+        if (correct_nightliness && !gha_workflow_run_job(job_name)) {
           known_jobs_set.add(job_name);
         }
       });


### PR DESCRIPTION
We merged https://github.com/pytorch/pytorch/pull/54779 and then immediately reverted it because a bunch of failing `annotate` workflow runs from PRs was showing up on the HUD as being attached to `master` commits.

This fixes the issue by adding a blocklist of GHA jobs that don't run on `master`. A better solution would instead directly identify whether a workflow was triggered by the `workflow_run` event, but this should suffice for now.

Progress:

- [x] New-style
- [ ] Old-style