### PR TITLE
Add Build workflow that runs on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 on: pull_request
 jobs:
-  pages:
+  build:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,12 @@
+name: Build
+on: pull_request
+jobs:
+  pages:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
The steps of this new job are just the same as the first three steps of the existing [`.github/workflows/pages.yml`](https://github.com/ezyang/pytorch-ci-hud/blob/32f63a7cc95ed38c4a7dab7002371e640b3ee454/.github/workflows/pages.yml) (the only difference is that it doesn't deploy to GitHub Actions), but it runs on PRs instead of just on `master`, in the hopes of avoiding the need for retroactive fixes like #33 in the future.