### PR TITLE
Fix infinite redirect when history is empty

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -23,7 +23,7 @@
       // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
       // https://username.github.io/repo-name/?p=/one/two&q=a=b~and~c=d#qwe
       // Otherwise, leave segmentCount as 0.
-      var segmentCount = 1;
+      var segmentCount = 0;
 
       var l = window.location;
       l.replace(


### PR DESCRIPTION
We rely on https://github.com/rafgraph/spa-github-pages to handle routing for GitHub pages which is purely static hosting (so it can't serve a React SPA by default). Since the URL moved from a project page `ezyang.github.io/pytorch-ci-hud` to a bare hostname `hud.pytorch.org`, we need to tell the redirecting 404 page to not slice off anything.

cc @seemethere @malfet 